### PR TITLE
Update PayplugAccountLoader.php

### DIFF
--- a/Services/PayplugAccountLoader.php
+++ b/Services/PayplugAccountLoader.php
@@ -113,7 +113,7 @@ class PayplugAccountLoader
      */
     public function editParameters(array $parametersArray)
     {
-        $parametersFile = $this->rootDir.'../config/parameters.yml';
+        $parametersFile = $this->rootDir.'/config/parameters.yml';
         
         $parser = new Parser();
         $dumper = new Dumper();


### PR DESCRIPTION
Hi,
%kernel.root_dir% return the path to the app folder
This fix the

[Symfony\Component\Debug\Exception\ContextErrorException]                                                                                          
  Warning: file_get_contents(/home/.../public_html/app../config/parameters.yml): failed to open stream: No such file or directory in /home/.../public_html/vendor/alcalyn/payplug-bundle/Alcalyn/PayplugBundle/Services/PayplugAccountLoader.php line 121  

catched in this command line:
php app/console payplug:account:update --test
